### PR TITLE
Updated with AWS code

### DIFF
--- a/.github/workflows/digger-plan.yml
+++ b/.github/workflows/digger-plan.yml
@@ -12,12 +12,6 @@ on:
 jobs:
   plan:
     runs-on: ubuntu-latest
-    permissions:    
-      contents: write      # required to merge PRs
-      id-token: write      # required for workload-identity-federation
-      pull-requests: write # required to post PR comments
-      statuses: write      # required to validate combined PR status
-
     steps:
       - uses: actions/checkout@v4
       # Unlike GCP; the role assumption is handled inline 

--- a/.github/workflows/digger-plan.yml
+++ b/.github/workflows/digger-plan.yml
@@ -1,0 +1,35 @@
+name: Digger Plan
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [ opened, synchronize ]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:    
+      contents: write      # required to merge PRs
+      id-token: write      # required for workload-identity-federation
+      pull-requests: write # required to post PR comments
+      statuses: write      # required to validate combined PR status
+
+    steps:
+      - uses: actions/checkout@v4
+      # Unlike GCP; the role assumption is handled inline 
+      - name: digger run
+        uses: diggerhq/digger@v0.2.0
+        with:
+          setup-aws: true
+          aws-role-to-assume: arn:aws:sts::${{ secrets.AccountID }}:assumed-role/${{secrets.RoleName}}/${{FunctionName}}
+          aws-region: us-east-1
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOCK_PROVIDER: aws
+          AWS_STORAGE_BUCKET: 'digger-lock-prod'
+    

--- a/.github/workflows/digger-plan.yml
+++ b/.github/workflows/digger-plan.yml
@@ -19,11 +19,15 @@ jobs:
         uses: diggerhq/digger@v0.2.0
         with:
           setup-aws: true
-          aws-role-to-assume: arn:aws:sts::${{ secrets.AccountID }}:assumed-role/${{secrets.RoleName}}/${{FunctionName}}
+          
+          #Uncomment below line if using OIDC
+          #aws-role-to-assume: arn:aws:sts::{secrets.AccountID}:assumed-role/{secrets.RoleName}/{FunctionName}
+         
+          #Comment the following two lines out if using OIDC. 
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ##End comment block
           aws-region: us-east-1
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LOCK_PROVIDER: aws
-          AWS_STORAGE_BUCKET: 'digger-lock-prod'
-    

--- a/.github/workflows/digger-plan.yml
+++ b/.github/workflows/digger-plan.yml
@@ -12,6 +12,12 @@ on:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    permissions:    
+      contents: write      # required to merge PRs
+      id-token: write      # required for workload-identity-federation
+      pull-requests: write # required to post PR comments
+      statuses: write      # required to validate combined PR status
+
     steps:
       - uses: actions/checkout@v4
       # Unlike GCP; the role assumption is handled inline 
@@ -31,3 +37,4 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+gcp_key.json
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ gcp_key.json
 
 # Local .terraform directories
 **/.terraform/*
-
+.terraform 
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # quickstart-actions-aws
+
+This is the repository for a sample quickstart action with digger. 
+
+# backend
+this folder will provision (most) of the backend required. 
+Main.tf provisions the following resources. 
+
+1. The Backend state bucket for terraform to store state in
+2. The required DynamoDB table for Digger to store locks. 
+
+# prod
+This is a sample terraform prod code that will (if given the chance) spin up a vpc + an EC2 instance, and required security groups. 
+The instance is locked down to not be accessible from outside the network. 
+
+# .github/workflows
+Contains digger-plan.yml with two different potential ways of authenticating against an AWS account. Please review the main digger documentation on details as to which scheme to use. 

--- a/backend/main.tf
+++ b/backend/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.0.0"  # Use an appropriate version
+      version = "5.23.1"  
     }
   }
 }
@@ -18,8 +18,24 @@ resource "random_string" "bucket_prefix" {
 
 resource "aws_s3_bucket" "default" {
   bucket = "${random_string.bucket_prefix.result}-bucket-tfstate"
-  acl    = "private"  # You can adjust the ACL as needed
-  versioning {
-    enabled = true
+}
+
+resource "aws_s3_bucket_versioning" "versioning_example" {
+  bucket = aws_s3_bucket.default.id
+  versioning_configuration {
+    status = "Enabled"
   }
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.default.id
+  acl    = "private"
+}
+
+
+resource "aws_dynamodb_table" "DiggerDynamoDBLockTable" {
+  name             = "DiggerDynamoDBLockTable"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
 }

--- a/backend/main.tf
+++ b/backend/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.0.0"  # Use an appropriate version
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"  # Replace with your desired AWS region
+}
+
+resource "random_string" "bucket_prefix" {
+  length  = 8
+  special = false
+}
+
+resource "aws_s3_bucket" "default" {
+  bucket = "${random_string.bucket_prefix.result}-bucket-tfstate"
+  acl    = "private"  # You can adjust the ACL as needed
+  versioning {
+    enabled = true
+  }
+}

--- a/digger.yml
+++ b/digger.yml
@@ -1,0 +1,3 @@
+projects:
+- name: production
+  dir: prod

--- a/prod/main.tf
+++ b/prod/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.0.0"  # Use an appropriate version
+    }
+  }
+    backend "s3" {
+    bucket = "8046b8f4c208f5bb-bucket-tfstate"
+    key    = "terraform/state"
+    region = "us-east-1"
+  }
+
+}
+
+provider "aws" {
+  region = "us-east-1"  # Replace with your desired AWS region
+}
+
+resource "aws_vpc" "vpc_network" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "terraform-network"
+  }
+}
+
+resource "aws_subnet" "vpc_subnet" {
+  vpc_id                  = aws_vpc.vpc_network.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "us-east-2a"  
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "terraform-subnet"
+  }
+}
+
+resource "aws_security_group" "security_group" {
+  name_prefix = "terraform-"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "vm_instance" {
+  ami             = "ami-0b17ac7207aae009f"  #Debian 11 (bullsey AMI provided by the Debian Project https://wiki.debian.org/Cloud/AmazonEC2Image/Bullseye)
+  instance_type   = "t2.micro"
+  subnet_id       = aws_subnet.vpc_subnet.id
+  security_groups = [aws_security_group.security_group.name]
+  tags = {
+    Name = "terraform-instance"
+  }
+}


### PR DESCRIPTION
Creating an equivalent TF layout to https://github.com/diggerhq/demo-conftest-gcp as per request. 

There are a few  minor differences;  

1. The digger plan  has provisions for both OIDC and direct authentication that can be used.
2. The demo infrastructure  provisioned is roughly equivalent to GCP, with the exception  of additional networking resources that  AWS requires for an instance  to be spun up.
3. As Digger  would prefer to have a DynamoDB database for state  locking, the provision for such is  included in the backend code. 
4. Documentation. 